### PR TITLE
Add `keyMoments` prompt

### DIFF
--- a/docs/04-prompt-options.md
+++ b/docs/04-prompt-options.md
@@ -74,6 +74,30 @@ npm run as -- text --rss "https://ajcwebdev.substack.com/feed" --prompt faq
 npm run as -- text --rss "https://ajcwebdev.substack.com/feed" --prompt chapterTitlesAndQuotes
 ```
 
+Extract key moments from the content with timestamps and explanations:
+
+```bash
+npm run as -- text --rss "https://ajcwebdev.substack.com/feed" --prompt keyMoments --chatgpt
+```
+
+Configure the number of key moments (default: 3):
+
+```bash
+npm run as -- text --rss "https://ajcwebdev.substack.com/feed" --prompt keyMoments --keyMomentsCount 5 --chatgpt
+```
+
+Set the duration of each key moment segment in seconds (default: 60):
+
+```bash
+npm run as -- text --rss "https://ajcwebdev.substack.com/feed" --prompt keyMoments --keyMomentDuration 90 --chatgpt
+```
+
+Combine multiple configurations:
+
+```bash
+npm run as -- text --rss "https://ajcwebdev.substack.com/feed" --prompt keyMoments --keyMomentsCount 2 --keyMomentDuration 60 --claude
+```
+
 ### Social Media Content, Blog Posts, and Songs
 
 ```bash

--- a/src/commander.ts
+++ b/src/commander.ts
@@ -1,5 +1,3 @@
-// src/commander.ts
-
 import { Command } from 'commander'
 import { processVideo } from './text/process-commands/video.ts'
 import { processPlaylist } from './text/process-commands/playlist.ts'
@@ -179,8 +177,16 @@ const textCommand = new Command('text')
   .option('--prompt <sections...>', 'Specify prompt sections to include (e.g., summary longChapters)')
   .option('--customPrompt <filePath>', 'Use a custom prompt from a markdown file')
   .option('--saveAudio', 'Do not delete intermediary audio files (e.g., .wav) after processing')
+  .option('--keyMomentsCount <number>', 'Number of key moments to extract (default: 3)', parseInt)
+  .option('--keyMomentDuration <number>', 'Duration of each key moment segment in seconds (default: 60)', parseInt)
   .action(async (options: ProcessingOptions) => {
     logInitialFunctionCall('textCommand', options)
+    if (options.keyMomentsCount !== undefined) {
+      l.dim(`Key moments count configured: ${options.keyMomentsCount}`)
+    }
+    if (options.keyMomentDuration !== undefined) {
+      l.dim(`Key moment duration configured: ${options.keyMomentDuration} seconds`)
+    }
     await processCommand(options)
   })
 

--- a/src/text/process-steps/04-select-prompt.ts
+++ b/src/text/process-steps/04-select-prompt.ts
@@ -3,6 +3,12 @@ import { err, l, logInitialFunctionCall } from '../utils/logging.ts'
 import { readFile } from '../utils/node-utils.ts'
 import type { ProcessingOptions } from '../utils/types.ts'
 
+// Default number of key moments to extract if not specified.
+const DEFAULT_KEY_MOMENTS_COUNT = 3
+
+// Default duration in seconds for each key moment if not specified.
+const DEFAULT_KEY_MOMENTS_DURATION = 60
+
 export const PROMPT_CHOICES: Array<{ name: string; value: string }> = [
   { name: 'Titles', value: 'titles' },
   { name: 'Summary', value: 'summary' },
@@ -52,7 +58,7 @@ export async function selectPrompts(options: ProcessingOptions) {
   const prompt = options.printPrompt || options.prompt || ['summary', 'longChapters']
 
   const validSections = prompt.filter(
-    (section): section is keyof typeof sections => 
+    (section): section is keyof typeof sections =>
       validPromptValues.has(section) && Object.hasOwn(sections, section)
   )
 
@@ -60,16 +66,16 @@ export async function selectPrompts(options: ProcessingOptions) {
 
   validSections.forEach((section) => {
     let instruction = sections[section].instruction
-    
+
     if (section === 'keyMoments') {
       const count = options.keyMomentsCount || DEFAULT_KEY_MOMENTS_COUNT
-      const duration = options.keyMomentDuration || 60
+      const duration = options.keyMomentDuration || DEFAULT_KEY_MOMENTS_DURATION
       l.dim(`Configuring keyMoments with count: ${count}, duration: ${duration}s`)
       instruction = instruction
         .replace('{COUNT}', count.toString())
         .replace('{DURATION}', duration.toString())
     }
-    
+
     text += instruction + "\n"
   })
 

--- a/src/text/process-steps/04-select-prompt.ts
+++ b/src/text/process-steps/04-select-prompt.ts
@@ -62,7 +62,7 @@ export async function selectPrompts(options: ProcessingOptions) {
     let instruction = sections[section].instruction
     
     if (section === 'keyMoments') {
-      const count = options.keyMomentsCount || 3
+      const count = options.keyMomentsCount || DEFAULT_KEY_MOMENTS_COUNT
       const duration = options.keyMomentDuration || 60
       l.dim(`Configuring keyMoments with count: ${count}, duration: ${duration}s`)
       instruction = instruction

--- a/src/text/process-steps/04-select-prompt.ts
+++ b/src/text/process-steps/04-select-prompt.ts
@@ -1,5 +1,3 @@
-// src/process-steps/04-select-prompt.ts
-
 import { sections } from '../prompts/sections.ts'
 import { err, l, logInitialFunctionCall } from '../utils/logging.ts'
 import { readFile } from '../utils/node-utils.ts'
@@ -27,6 +25,7 @@ export const PROMPT_CHOICES: Array<{ name: string; value: string }> = [
   { name: 'Social Post (X)', value: 'x' },
   { name: 'Social Post (Facebook)', value: 'facebook' },
   { name: 'Social Post (LinkedIn)', value: 'linkedin' },
+  { name: 'Key Moments', value: 'keyMoments' },
 ]
 
 const validPromptValues = new Set(PROMPT_CHOICES.map(choice => choice.value))
@@ -60,7 +59,18 @@ export async function selectPrompts(options: ProcessingOptions) {
   l.dim(`${JSON.stringify(validSections, null, 2)}`)
 
   validSections.forEach((section) => {
-    text += sections[section].instruction + "\n"
+    let instruction = sections[section].instruction
+    
+    if (section === 'keyMoments') {
+      const count = options.keyMomentsCount || 3
+      const duration = options.keyMomentDuration || 60
+      l.dim(`Configuring keyMoments with count: ${count}, duration: ${duration}s`)
+      instruction = instruction
+        .replace('{COUNT}', count.toString())
+        .replace('{DURATION}', duration.toString())
+    }
+    
+    text += instruction + "\n"
   })
 
   text += "Format the output like so:\n\n"

--- a/src/text/prompts/sections.ts
+++ b/src/text/prompts/sections.ts
@@ -1,5 +1,3 @@
-// src/prompts/prompts.ts
-
 export const sections = {
   titles: {
     instruction: `- Write 5 potential titles for the video.
@@ -242,5 +240,46 @@ export const sections = {
     example: `## Song
     
     Lyrics to the song.\n`
+  },
+
+  keyMoments: {
+    instruction: `- Identify the most compelling segments from the transcript ({COUNT} by default).
+  - Each segment should be approximately {DURATION} seconds long.
+  - Look for particularly insightful explanations, key turning points, or any segments that stand out as especially valuable or engaging.
+  - For each key moment:
+    - Find the exact start timestamp from the transcript
+    - Calculate the end timestamp based on the specified duration
+    - Extract and include the ACTUAL transcript text from that time range (do not use placeholder text)
+    - Write a brief explanation (1-2 sentences) of what makes this segment valuable
+  - IMPORTANT: You must copy the exact transcript text with timestamps from the specified time range. Do not summarize or paraphrase.`,
+    example: `## Key Moments
+
+    ### 1. 00:12:45 - 00:13:45
+
+    **Why it matters:** This segment stands out for its clear and concise explanation of the core concept, making complex ideas accessible to the audience.
+
+    **Transcript:**
+    [00:12:45] So when we talk about microservices, what we're really discussing is a fundamental shift in how we think about application architecture.
+    [00:12:52] Instead of building one monolithic application, we're breaking it down into smaller, independent services.
+    [00:13:01] Each service has its own database, its own deployment cycle, and its own team responsible for it.
+    [00:13:09] This might sound like more work initially, and honestly, it is.
+    [00:13:15] But the benefits become clear when you need to scale specific parts of your application.
+    [00:13:22] You can scale just the payment service during Black Friday without touching the user profile service.
+    [00:13:30] That's the kind of flexibility that modern applications need to stay competitive.
+    [00:13:38] And it's why companies like Netflix and Amazon pioneered this approach.
+
+    ### 2. 00:24:30 - 00:25:30
+
+    **Why it matters:** The speaker provides a compelling real-world example that perfectly illustrates the main theme.
+
+    **Transcript:**
+    [00:24:30] Let me tell you about a client I worked with last year who was struggling with their monolithic e-commerce platform.
+    [00:24:37] Every time they wanted to update the recommendation engine, they had to redeploy the entire application.
+    [00:24:44] This meant scheduling downtime, coordinating with multiple teams, and crossing their fingers that nothing would break.
+    [00:24:52] After we migrated to microservices, they could update recommendations in real-time.
+    [00:24:58] The results were immediate - conversion rates jumped by 23% in the first month.
+    [00:25:05] But more importantly, their development velocity increased dramatically.
+    [00:25:11] Teams could work independently, deploy when ready, and iterate quickly based on user feedback.
+    [00:25:19] That's the real power of this architecture - it's not just about technology, it's about enabling business agility.`,
   },
 }

--- a/src/text/utils/types.ts
+++ b/src/text/utils/types.ts
@@ -1,5 +1,3 @@
-// src/utils/types.ts
-
 export interface ShowNote {
   id?: number
   showLink?: string
@@ -70,6 +68,8 @@ export type ProcessingOptions = {
   metaDate?: string[]
   metaInfo?: boolean
   metaShownotes?: boolean
+  keyMomentsCount?: number
+  keyMomentDuration?: number
   [key: string]: any
 }
 export interface VideoInfo {


### PR DESCRIPTION
## Explanation

- This takes a slightly different approach from what we did on our [last stream](https://www.youtube.com/watch?v=t0CZGHk2FUM) ([commit for reference](https://github.com/autoshow/autoshow-cli/commit/9f9adebff7538659ba937eafd1c2d56efc260aa8)).
- Instead of adding a regex to the `05-run-llm.ts` process step, all the logic is contained in `04-select-prompt.ts` and `sections.ts`.
- Will test [on stream today](https://www.youtube.com/watch?v=vJkAFQBkCoY) with @nickytonline.

## Docs

Extract key moments from the content with timestamps and explanations:

```bash
npm run as -- text --rss "https://ajcwebdev.substack.com/feed" --prompt keyMoments --chatgpt
```

Configure the number of key moments (default: 3):

```bash
npm run as -- text --rss "https://ajcwebdev.substack.com/feed" --prompt keyMoments --keyMomentsCount 5 --chatgpt
```

Set the duration of each key moment segment in seconds (default: 60):

```bash
npm run as -- text --rss "https://ajcwebdev.substack.com/feed" --prompt keyMoments --keyMomentDuration 90 --chatgpt
```

Combine multiple configurations:

```bash
npm run as -- text --rss "https://ajcwebdev.substack.com/feed" --prompt keyMoments --keyMomentsCount 2 --keyMomentDuration 60 --claude
```

@nickytonline 